### PR TITLE
[RFC] Make usable

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -131,12 +131,8 @@ pub fn number_of_roots_buffered() -> usize {
 ///
 /// impl Trace for Gadget {
 ///     fn trace(&mut self, tracer: &mut Tracer) {
-///         if let Some(ref mut p) = self.parent {
-///             tracer(p);
-///         }
-///         for child in &mut self.children {
-///             tracer(child);
-///         }
+///         self.parent.trace(tracer);
+///         self.children.trace(tracer);
 ///     }
 /// }
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,8 +449,12 @@ impl<T: Trace> Deref for Cc<T> {
 
     #[inline(always)]
     fn deref(&self) -> &T {
-        unsafe {
-            &self._ptr.as_ref().value
+        if self.strong_count() > 0 {
+            unsafe {
+                &self._ptr.as_ref().value
+            }
+        } else {
+            panic!("Invalid access during cycle collection");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -815,7 +815,7 @@ impl<T: fmt::Debug + Trace> fmt::Debug for Weak<T> {
 impl<T: Trace> Trace for Cc<T> {
     fn trace(&mut self, tracer: &mut Tracer) {
         unsafe {
-            Trace::trace(self._ptr.as_mut(), tracer);
+            tracer(self._ptr.as_mut());
         }
     }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -240,6 +240,17 @@ mod impls {
         }
     }
 
+    mod vec {
+        pub use super::*;
+        impl<T: Trace> Trace for Vec<T> {
+            fn trace(&mut self, tracer: &mut Tracer) {
+                for t in self {
+                    t.trace(tracer);
+                }
+            }
+        }
+    }
+
     mod ffi {
         pub use super::*;
         use std::ffi;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -197,7 +197,12 @@ mod impls {
 
         impl<T: Trace> Trace for cell::RefCell<T> {
             fn trace(&mut self, tracer: &mut Tracer) {
-                self.borrow_mut().trace(tracer);
+                // If the RefCell is currently borrowed we
+                // assume there's an outstanding reference to this
+                // cycle so it's ok if we don't trace through it.
+                // If the borrow gets leaked somehow then we're going
+                // to leak the cycle.
+                self.try_borrow_mut().map(|x| x.trace(tracer));
             }
         }
     }


### PR DESCRIPTION
This collection of commits makes the cycle collector usable. It still uses recursion during tracing and may have other bugs, but all the basic stuff is there.