### PR TITLE
Fix issue9

### DIFF
--- a/examples/cyclical_list.rs
+++ b/examples/cyclical_list.rs
@@ -1,0 +1,26 @@
+extern crate bacon_rajan_cc;
+use bacon_rajan_cc::{collect_cycles, Cc, Trace, Tracer};
+use std::cell::RefCell;
+
+struct List(Vec<Cc<RefCell<List>>>);
+impl Trace for List {
+    fn trace(&mut self, tracer: &mut Tracer) {
+        self.0.trace(tracer);
+    }
+}
+
+fn main() {
+    {
+        let a = Cc::new(RefCell::new(List(Vec::new())));
+        let b = Cc::new(RefCell::new(List(Vec::new())));
+        {
+            let mut a = a.borrow_mut();
+            a.0.push(b.clone());
+        }
+        {
+            let mut b = b.borrow_mut();
+            b.0.push(a.clone());
+        }
+    }
+    collect_cycles();
+}


### PR DESCRIPTION
See #9 for more context. This pull request adds an example (so it's easier to run with valgrind),
and the fix.

It'd be ideal if `collect_white` can take a `&mut Vec<NonNull<CcBoxPtr>>` instead of `Rc<RefCell<Vec<NonNull<CcBoxPtr>>>>` to reduce some overhead. But my fight with the borrow checker wasn't successful.