### PR TITLE
added failing refcell test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1223,16 +1223,16 @@ mod tests {
             }
         }
         {
-            let w;
+            let q;
             {
                 let z = A::new(count.clone(), None);
                 let y = A::new(count.clone(), Some(z.clone()));
                 let x = A::new(count.clone(), Some(y));
-                *z.next_op.borrow_mut() = Some(x);
-                w = z.clone();
+                *z.next_op.borrow_mut() = Some(x.clone());
+                q = x;
             }
             collect_cycles();
-            *w.next_op.borrow_mut() = None;
+            *q.next_op.borrow_mut() = None;
         }
         collect_cycles();
         assert_eq!(count.get(), 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1220,8 +1220,8 @@ mod tests {
             let x = A::new(count.clone(), Some(y));
             *z.next_op.borrow_mut() = Some(x);
             let _w = z.clone();
-            collect_cycles();
         }
+        collect_cycles();
         assert_eq!(count.get(), 0);
     }
 }


### PR DESCRIPTION
Added a test to demonstrate the problem with not being able to recursively trace through a cycle more than once as it is with RefCell trace impl. They're may be other more efficient work arounds in the collect_cycles method. Just needs a little thought.