### PR TITLE
Fix a memory leak bug caused by strong() reaching 0 in previous collector stages

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -306,6 +306,9 @@ fn collect_roots() {
         for s in v.drain(..) {
             let ptr : &dyn CcBoxPtr = unsafe { s.as_ref() };
             ptr.data().buffered.set(false);
+            if ptr.color() == Color::Black && ptr.strong() == 0 {
+                ptr.data().color.set(Color::White);
+            }
             collect_white(ptr, &mut white);
         }
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1246,24 +1246,6 @@ mod tests {
             ty: Cc<Cc<i32>>,
         }
 
-        #[derive(Debug)]
-        struct T {
-            value: i32,
-        }
-
-        impl std::ops::Drop for T {
-            fn drop(&mut self) {
-                println!("dropping T");
-            }
-        }
-
-        impl Trace for T {
-            fn trace(&self, tracer: &mut Tracer) {
-                println!("tracing T");
-                self.value.trace(tracer);
-            }
-        }
-
         // If either of the drops below is missing, we don't get a leak
         let ty = Cc::new(5);
         drop(ty.clone());


### PR DESCRIPTION
In some cases, the strong() count of a Cc  reaches 0 due to the Cc pointing at it being dropped in the mark_roots() pass. The pointed at Cc gets marked as black, while still having a count of 0, which prevents it from being collected in collect_cycles(). This PR fixes this bug by adding a check to the loop over the roots in collect_cycles().

MRE:
```rust
#[derive(Debug, Clone)]
struct S {
    ty: Cc<Cc<i32>>,
}

let ty = Cc::new(5);
drop(ty.clone());
let s = S { ty: Cc::new(ty) };
drop(s.ty.clone());

std::mem::drop(s);
collect_cycles();
```

<details><summary>Miri output before the fix:</summary>

```bash
$ cargo miri test -- double_indirection
running 1 test
test tests::test_no_leak_with_double_indirection ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 20 filtered out

The following memory was leaked: alloc100029 (Rust heap, size: 32, align: 8) {
    0x00 │ 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 │ ................
    0x10 │ 00 00 __ __ __ __ __ __ 05 00 00 00 __ __ __ __ │ ..░░░░░░....░░░░
}

```
</details>

<details><summary>Valgrind output before the fix:</summary>

```bash
$ valgrind --leak-check=full -s  -- target/debug/deps/bacon_rajan_cc-a9a3d6ea21a820b8

==3070937== 
==3070937== HEAP SUMMARY:
==3070937==     in use at exit: 32 bytes in 1 blocks
==3070937==   total heap usage: 1,251 allocs, 1,250 frees, 125,761 bytes allocated
==3070937== 
==3070937== 32 bytes in 1 blocks are definitely lost in loss record 1 of 1
==3070937==    at 0x483E77F: malloc (vg_replace_malloc.c:307)
==3070937==    by 0x12AF7B: alloc::alloc::alloc (alloc.rs:86)
==3070937==    by 0x12B04A: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==3070937==    by 0x12B719: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==3070937==    by 0x12AEDC: alloc::alloc::exchange_malloc (alloc.rs:316)
==3070937==    by 0x126961: new<bacon_rajan_cc::CcBox<i32>> (boxed.rs:185)
==3070937==    by 0x126961: bacon_rajan_cc::Cc<T>::new (lib.rs:258)
==3070937==    by 0x142ABC: bacon_rajan_cc::tests::test_no_leak_with_double_indirection (lib.rs:1268)
==3070937==    by 0x13967C: bacon_rajan_cc::tests::test_no_leak_with_double_indirection::{{closure}} (lib.rs:1242)
==3070937==    by 0x13A9BD: core::ops::function::FnOnce::call_once (function.rs:227)
==3070937==    by 0x16E6D5: call_once<fn(),()> (function.rs:227)
==3070937==    by 0x16E6D5: test::__rust_begin_short_backtrace (lib.rs:576)
==3070937==    by 0x16D135: call_once<(),FnOnce<()>,alloc::alloc::Global> (boxed.rs:1546)
==3070937==    by 0x16D135: call_once<(),alloc::boxed::Box<FnOnce<()>, alloc::alloc::Global>> (panic.rs:344)
==3070937==    by 0x16D135: do_call<std::panic::AssertUnwindSafe<alloc::boxed::Box<FnOnce<()>, alloc::alloc::Global>>,()> (panicking.rs:379)
==3070937==    by 0x16D135: try<(),std::panic::AssertUnwindSafe<alloc::boxed::Box<FnOnce<()>, alloc::alloc::Global>>> (panicking.rs:343)
==3070937==    by 0x16D135: catch_unwind<std::panic::AssertUnwindSafe<alloc::boxed::Box<FnOnce<()>, alloc::alloc::Global>>,()> (panic.rs:431)
==3070937==    by 0x16D135: run_test_in_process (lib.rs:599)
==3070937==    by 0x16D135: test::run_test::run_test_inner::{{closure}} (lib.rs:491)
==3070937==    by 0x14857D: {{closure}} (lib.rs:518)
==3070937==    by 0x14857D: std::sys_common::backtrace::__rust_begin_short_backtrace (backtrace.rs:125)
==3070937== 
==3070937== LEAK SUMMARY:
==3070937==    definitely lost: 32 bytes in 1 blocks
==3070937==    indirectly lost: 0 bytes in 0 blocks
==3070937==      possibly lost: 0 bytes in 0 blocks
==3070937==    still reachable: 0 bytes in 0 blocks
==3070937==         suppressed: 0 bytes in 0 blocks
==3070937== 
==3070937== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
</details>
