### PR TITLE
Add more type implementations

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+unstable_features = true
+normalize_comments = true
+# overflow_delimited_expr = false
+reorder_impl_items = false
+use_field_init_shorthand = true
+# format_code_in_doc_comments = true
+imports_layout = "HorizontalVertical"
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+# wrap_comments = true

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -153,8 +153,137 @@ mod impls {
         }
 
         mod tuples {
-            // impl Trace for tuple {
-            // }
+            use super::*;
+
+            // macro for implementing n-ary tuple functions and operations
+            // from the core library
+            macro_rules! tuple_impls {
+                ($(
+                    $Tuple:ident {
+                        $(($idx:tt) -> $T:ident)+
+                    }
+                )+) => {
+                    $(
+                        impl<$($T: Trace),+> Trace for ($($T,)+) where last_type!($($T,)+): ?Sized {
+                            fn trace(&self, t: &mut Tracer) {
+                                $(
+                                    self.$idx.trace(t);
+                                )+
+                            }
+                        }
+                    )+
+                }
+            }
+
+            macro_rules! last_type {
+                ($a:ident,) => { $a };
+                ($a:ident, $($rest_a:ident,)+) => { last_type!($($rest_a,)+) };
+            }
+
+            tuple_impls! {
+                Tuple1 {
+                    (0) -> A
+                }
+                Tuple2 {
+                    (0) -> A
+                    (1) -> B
+                }
+                Tuple3 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                }
+                Tuple4 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                }
+                Tuple5 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                    (4) -> E
+                }
+                Tuple6 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                    (4) -> E
+                    (5) -> F
+                }
+                Tuple7 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                    (4) -> E
+                    (5) -> F
+                    (6) -> G
+                }
+                Tuple8 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                    (4) -> E
+                    (5) -> F
+                    (6) -> G
+                    (7) -> H
+                }
+                Tuple9 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                    (4) -> E
+                    (5) -> F
+                    (6) -> G
+                    (7) -> H
+                    (8) -> I
+                }
+                Tuple10 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                    (4) -> E
+                    (5) -> F
+                    (6) -> G
+                    (7) -> H
+                    (8) -> I
+                    (9) -> J
+                }
+                Tuple11 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                    (4) -> E
+                    (5) -> F
+                    (6) -> G
+                    (7) -> H
+                    (8) -> I
+                    (9) -> J
+                    (10) -> K
+                }
+                Tuple12 {
+                    (0) -> A
+                    (1) -> B
+                    (2) -> C
+                    (3) -> D
+                    (4) -> E
+                    (5) -> F
+                    (6) -> G
+                    (7) -> H
+                    (8) -> I
+                    (9) -> J
+                    (10) -> K
+                    (11) -> L
+                }
+            }
         }
     }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -25,7 +25,7 @@ pub trait Trace {
 }
 
 mod impls {
-    pub use super::*;
+    use super::*;
 
     mod primitives {
         use super::*;
@@ -159,7 +159,7 @@ mod impls {
     }
 
     mod boxed {
-        pub use super::*;
+        use super::*;
 
         impl<T: Trace + ?Sized> Trace for Box<T> {
             fn trace(&self, tracer: &mut Tracer) {
@@ -169,7 +169,7 @@ mod impls {
     }
 
     mod cell {
-        pub use super::*;
+        use super::*;
         use std::cell;
 
         impl<T: Copy + Trace + ?Sized> Trace for cell::Cell<T> {
@@ -188,7 +188,7 @@ mod impls {
     }
 
     mod collections {
-        pub use super::*;
+        use super::*;
         use std::collections;
 
         impl<K: Trace, V: Trace> Trace for collections::BTreeMap<K, V> {
@@ -243,7 +243,7 @@ mod impls {
     }
 
     mod vec {
-        pub use super::*;
+        use super::*;
         impl<T: Trace> Trace for Vec<T> {
             fn trace(&self, tracer: &mut Tracer) {
                 for t in self {
@@ -254,141 +254,141 @@ mod impls {
     }
 
     mod string {
-        pub use super::*;
+        use super::*;
         impl Trace for String {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
     }
 
     mod ffi {
-        pub use super::*;
+        use super::*;
         use std::ffi;
 
         impl Trace for ffi::CStr {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for ffi::CString {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for ffi::NulError {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for ffi::OsStr {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for ffi::OsString {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
     }
 
     mod io {
-        pub use super::*;
+        use super::*;
         use std::io;
 
         impl<T> Trace for io::BufReader<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T: io::Write> Trace for io::BufWriter<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for io::Cursor<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for io::Empty {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for io::Error {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for io::IntoInnerError<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T: io::Write> Trace for io::LineWriter<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for io::Lines<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for io::Repeat {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for io::Sink {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for io::Split<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for io::Stderr {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for io::Stdin {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for io::Stdout {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for io::Take<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
     }
 
     mod net {
-        pub use super::*;
+        use super::*;
         use std::net;
 
         impl Trace for net::AddrParseError {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for net::Ipv4Addr {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for net::Ipv6Addr {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for net::SocketAddrV4 {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for net::SocketAddrV6 {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for net::TcpListener {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for net::TcpStream {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for net::UdpSocket {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
     }
 
     mod option {
-        pub use super::*;
+        use super::*;
 
         impl<T: Trace> Trace for Option<T> {
             fn trace(&self, tracer: &mut Tracer) {
@@ -400,70 +400,70 @@ mod impls {
     }
 
     mod path {
-        pub use super::*;
+        use super::*;
         use std::path;
 
         impl Trace for path::Path {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for path::PathBuf {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
     }
 
     mod process {
-        pub use super::*;
+        use super::*;
         use std::process;
 
         impl Trace for process::Child {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for process::ChildStderr {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for process::ChildStdin {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for process::ChildStdout {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for process::Command {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for process::ExitStatus {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for process::Output {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for process::Stdio {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
     }
 
     mod rc {
-        pub use super::*;
+        use super::*;
         use std::rc;
 
         impl<T> Trace for rc::Rc<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for rc::Weak<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
     }
 
     mod result {
-        pub use super::*;
+        use super::*;
 
         impl<T: Trace, U: Trace> Trace for Result<T, U> {
             fn trace(&self, tracer: &mut Tracer) {
@@ -476,31 +476,31 @@ mod impls {
     }
 
     mod sync {
-        pub use super::*;
+        use super::*;
         use std::sync;
 
         impl<T> Trace for sync::Arc<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for sync::Barrier {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for sync::Condvar {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for sync::Mutex<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for sync::Once {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for sync::PoisonError<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T: Trace> Trace for sync::RwLock<T> {
@@ -513,23 +513,23 @@ mod impls {
     }
 
     mod thread {
-        pub use super::*;
+        use super::*;
         use std::thread;
 
         impl Trace for thread::Builder {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for thread::JoinHandle<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl<T> Trace for thread::LocalKey<T> {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
 
         impl Trace for thread::Thread {
-            fn trace(&self, _tracer: &mut Tracer) { }
+            fn trace(&self, _tracer: &mut Tracer) {}
         }
     }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -28,66 +28,37 @@ mod impls {
     pub use super::*;
 
     mod primitives {
-        pub use super::*;
+        use super::*;
 
-        impl Trace for bool {
-            fn trace(&self, _tracer: &mut Tracer) { }
+        macro_rules! impl_prim {
+            ($($t:ty,)*) => {
+                $(
+                    impl Trace for $t {
+                        fn trace(&self, _tracer: &mut Tracer) {}
+                    }
+                )*
+            }
         }
 
-        impl Trace for char {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for f32 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for f64 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for i16 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for i32 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for i64 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for i8 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for isize {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for str {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for u16 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for u32 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for u64 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for u8 {
-            fn trace(&self, _tracer: &mut Tracer) { }
-        }
-
-        impl Trace for usize {
-            fn trace(&self, _tracer: &mut Tracer) { }
+        impl_prim! {
+            bool,
+            char,
+            f32,
+            f64,
+            i8,
+            i16,
+            i32,
+            i64,
+            i128,
+            isize,
+            u8,
+            u16,
+            u32,
+            u64,
+            u128,
+            usize,
+            str,
+            (),
         }
 
         impl<'a, T: Trace> Trace for &'a mut [T] {

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -81,76 +81,18 @@ mod impls {
             }
         }
 
-        mod arrays {
-            pub use super::*;
+        // requires 1.51
+        // mod arrays {
+        //     use super::*;
 
-            // impl<T: Trace> Trace for [T; 0] {
-            // }
-            // impl<T: Trace> Trace for [T; 1] {
-            // }
-            // impl<T: Trace> Trace for [T; 2] {
-            // }
-            // impl<T: Trace> Trace for [T; 3] {
-            // }
-            // impl<T: Trace> Trace for [T; 4] {
-            // }
-            // impl<T: Trace> Trace for [T; 5] {
-            // }
-            // impl<T: Trace> Trace for [T; 6] {
-            // }
-            // impl<T: Trace> Trace for [T; 7] {
-            // }
-            // impl<T: Trace> Trace for [T; 8] {
-            // }
-            // impl<T: Trace> Trace for [T; 9] {
-            // }
-            // impl<T: Trace> Trace for [T; 10] {
-            // }
-            // impl<T: Trace> Trace for [T; 11] {
-            // }
-            // impl<T: Trace> Trace for [T; 12] {
-            // }
-            // impl<T: Trace> Trace for [T; 13] {
-            // }
-            // impl<T: Trace> Trace for [T; 14] {
-            // }
-            // impl<T: Trace> Trace for [T; 15] {
-            // }
-            // impl<T: Trace> Trace for [T; 16] {
-            // }
-            // impl<T: Trace> Trace for [T; 17] {
-            // }
-            // impl<T: Trace> Trace for [T; 18] {
-            // }
-            // impl<T: Trace> Trace for [T; 19] {
-            // }
-            // impl<T: Trace> Trace for [T; 20] {
-            // }
-            // impl<T: Trace> Trace for [T; 21] {
-            // }
-            // impl<T: Trace> Trace for [T; 22] {
-            // }
-            // impl<T: Trace> Trace for [T; 23] {
-            // }
-            // impl<T: Trace> Trace for [T; 24] {
-            // }
-            // impl<T: Trace> Trace for [T; 25] {
-            // }
-            // impl<T: Trace> Trace for [T; 26] {
-            // }
-            // impl<T: Trace> Trace for [T; 27] {
-            // }
-            // impl<T: Trace> Trace for [T; 28] {
-            // }
-            // impl<T: Trace> Trace for [T; 29] {
-            // }
-            // impl<T: Trace> Trace for [T; 30] {
-            // }
-            // impl<T: Trace> Trace for [T; 31] {
-            // }
-            // impl<T: Trace> Trace for [T; 32] {
-            // }
-        }
+        //     impl<T: Trace, const N: usize> Trace for [T; N] {
+        //         fn trace(&self, tracer: &mut Tracer) {
+        //             for t in self {
+        //                 t.trace(tracer);
+        //             }
+        //         }
+        //     }
+        // }
 
         mod tuples {
             use super::*;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -61,9 +61,21 @@ mod impls {
             (),
         }
 
-        impl<'a, T: Trace> Trace for &'a mut [T] {
+        impl<T: Trace + ?Sized> Trace for &'_ T {
             fn trace(&self, tracer: &mut Tracer) {
-                for t in &self[..] {
+                (**self).trace(tracer)
+            }
+        }
+
+        impl<T: Trace + ?Sized> Trace for &'_ mut T {
+            fn trace(&self, tracer: &mut Tracer) {
+                (**self).trace(tracer)
+            }
+        }
+
+        impl<T: Trace> Trace for [T] {
+            fn trace(&self, tracer: &mut Tracer) {
+                for t in self {
                     t.trace(tracer);
                 }
             }


### PR DESCRIPTION
I have added `Trace` impls for the following types:

- `i128`
- `u128`
- `()`
- `&T where T: Trace`
- `&mut T where T: Trace`
- `[T] where T: Trace`
- `(T, U, ...) where T, U, ...: Trace` (up to 12, like the standard library)

An implementation for arrays (`[T; N]`) is there, but commented out, since it will make the minimum required Rust version 1.51 (up from 1.34).