### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -222,8 +222,8 @@ fn mark_roots() {
     });
 
     let mut new_roots : Vec<_> = old_roots.into_iter().filter_map(|s| {
-        let keep = unsafe {
-            let box_ptr : &dyn CcBoxPtr = s.as_ref();
+        let keep = {
+            let box_ptr : &dyn CcBoxPtr = unsafe { s.as_ref() };
             if box_ptr.color() == Color::Purple {
                 mark_gray(box_ptr);
                 true
@@ -231,7 +231,7 @@ fn mark_roots() {
                 box_ptr.data().buffered.set(false);
 
                 if box_ptr.color() == Color::Black && box_ptr.strong() == 0 {
-                    free(s);
+                    unsafe { free(s) };
                 }
 
                 false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,15 +362,15 @@ impl<T: 'static + Trace> Cc<T> {
     #[inline]
     pub fn try_unwrap(self) -> Result<T, Cc<T>> {
         if self.is_unique() {
-            unsafe {
+            
                 // Copy the contained object.
-                let val = ptr::read(&*self);
+                let val = unsafe { ptr::read(&*self) };
                 // Destruct the box and skip our Drop. We can ignore the
                 // refcounts because we know we're unique.
-                dealloc(self._ptr.cast().as_ptr(), Layout::new::<CcBox<T>>());
+                unsafe { dealloc(self._ptr.cast().as_ptr(), Layout::new::<CcBox<T>>()) };
                 forget(self);
                 Ok(val)
-            }
+            
         } else {
             Err(self)
         }


### PR DESCRIPTION
In these functions you use the unsafe keyword for many safe expressions. However, I found that only 4 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the dealloc()\read()\free()\as_ref() function(these are unsafe functions)

@jrmuizel
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 